### PR TITLE
feat: modal link expansion in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,19 @@ Alternatively, you can use the `bs-target` and `bs-toggle` attributes directly.
 
 ```markdown
 [Button Text]{bs-target="#<modal-id>" bs-toggle="modal"}
+[Button Text](#<modal-id>){bs-toggle="modal"}
+```
+
+Or rely on the extension to automatically expand to the correct HTML syntax:
+
+```markdown
+[Button Text](#<modal-id>)
 ```
 
 #### Modal Container
+
+> [!Important]
+> The identifier needs to start with `modal-` to be recognised by the extension as a modal container.
 
 ```{.markdown shortcodes=false}
 :::: {#modal-<id> description="<accessibility-description>" <options>}

--- a/_extensions/modal/modal-filter.lua
+++ b/_extensions/modal/modal-filter.lua
@@ -256,5 +256,16 @@ end
 
 return {
   { Meta = get_modal_meta },
-  { Div = modal }
+  { Div = modal },
+  { Link = function(el)
+      if el.target and not el.target:match('^#modal%-') then
+        return el
+      end
+      if el.attributes['data-bs-toggle'] == 'modal' then
+        return el
+      end
+      el.attributes['data-bs-target'] = el.target
+      el.attributes['data-bs-toggle'] = 'modal'
+      return el
+    end }
 }

--- a/example.qmd
+++ b/example.qmd
@@ -66,9 +66,20 @@ Alternatively, you can use the `bs-target` and `bs-toggle` attributes directly.
 
 ```markdown
 [Button Text]{bs-target="#<modal-id>" bs-toggle="modal"}
+[Button Text](#<modal-id>){bs-toggle="modal"}
+```
+
+Or rely on the extension to automatically expand to the correct HTML syntax:
+
+```markdown
+[Button Text](#<modal-id>)
 ```
 
 #### Modal Container
+
+:::: {.callout-important}
+The identifier needs to start with `modal-` to be recognised by the extension as a modal container.
+:::
 
 ```{.markdown shortcodes=false}
 :::: {#modal-<id> description="<accessibility-description>" <options>}
@@ -86,7 +97,7 @@ Footer content goes here.
 
 {{< modal toggle target="modal-basic" label="Open Basic Modal" >}}
 
-[This sentence is also a trigger to open the modal.]{bs-target="#modal-basic" bs-toggle="modal"}
+[This sentence is also a trigger to open the modal.](#modal-basic)
 
 :::: {#modal-basic}
 
@@ -103,7 +114,7 @@ This is a basic modal example.
 ```{.markdown shortcodes=false}
 {{< modal toggle target="modal-basic" label="Open Basic Modal" >}}
 
-[This is also a trigger button for the modal]{bs-target="1modal-basic" bs-toggle="modal"}
+[This sentence is also a trigger to open the modal.](#modal-basic)
 
 :::: {#modal-basic}
 


### PR DESCRIPTION
Expand `[text](#modal-<id>)` into the correct HTML syntax to trigger the modal.

Fixes #2