### PR TITLE
fix: preserve non-modal Divs in filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Preserve non-modal Divs in filter (return `nil` instead of `pandoc.Null()`), which previously deleted every Div without a `modal-` identifier from the output.
+
 ## 1.4.1 (2026-04-15)
 
 ### Refactoring

--- a/_extensions/modal/modal-filter.lua
+++ b/_extensions/modal/modal-filter.lua
@@ -75,7 +75,7 @@ end
 --- @return table|nil Pandoc Div structure for modal, or nil if not applicable.
 local function modal(el)
   if not quarto.doc.is_format("html:js") or not quarto.doc.has_bootstrap() or not (el.identifier:match("^modal%-")) then
-    return pandoc.Null()
+    return nil
   end
 
   quarto.doc.add_html_dependency({


### PR DESCRIPTION
The Div handler in `modal-filter.lua` returned `pandoc.Null()` when the Div was not a modal, which deletes the element from the output.
Since the filter runs on every Div, any document containing non-modal Divs (gallery wrappers, custom layout divs, etc.) had all of them silently wiped.

Return `nil` instead, which passes the Div through unchanged and matches the `@return table|nil` contract already documented on the function.