### PR TITLE
feat: action v1.4.2 review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 1.5.0 (2026-05-28)
-
 ### New Features
 
 - feat: Add friendly `size` aliases (`small`, `medium`/`default`, `large`, `extra-large`/`xlarge`) and warn on unknown values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## Unreleased
 
+## 1.5.0 (2026-05-28)
+
+### New Features
+
+- feat: Add friendly `size` aliases (`small`, `medium`/`default`, `large`, `extra-large`/`xlarge`) and warn on unknown values.
+- feat: Add `close-button` attribute to suppress the header close button and `close-button-label` to override its `aria-label`.
+- feat: Validate `description` references and warn when the referenced identifier is absent from the document.
+- feat: Detect nested modal containers and warn (Bootstrap does not support modal nesting).
+- feat: Warn when a Div carries modal-specific attributes but its identifier is missing the required `modal-` prefix.
+- feat: Warn on unknown `fullscreen` values instead of silently emitting no class.
+
+### Bug Fixes
+
+- fix: Preserve pre-existing `bs-toggle`/`bs-target` attributes on link expansion; the filter runs at `pre-quarto` where attributes have not yet been prefixed with `data-`, so writes now use the unprefixed names and detect existing values correctly.
+
+### Refactoring
+
+- refactor: Clarify the misleading filter-function comment to document that the callback is invoked on every Div and processes only those whose identifier starts with `modal-`.
+- refactor: Synchronise shared modules (`content-extraction.lua`, `html.lua`, `logging.lua`, `metadata.lua`, `pandoc-helpers.lua`, `string.lua`) with the canonical version.
+
+### Documentation
+
+- docs: Document friendly size aliases, `close-button`/`close-button-label` attributes, `description` validation, and the nested-modal warning.
+
 ## 1.4.2 (2026-04-22)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It allows you to define modal buttons and containers using shortcodes, making it
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-modal@1.5.0
+quarto add mcanouil/quarto-modal@1.4.2
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It allows you to define modal buttons and containers using shortcodes, making it
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-modal@1.4.2
+quarto add mcanouil/quarto-modal@1.5.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -75,6 +75,7 @@ Or rely on the extension to automatically expand to the correct HTML syntax:
 
 > [!Important]
 > The identifier needs to start with `modal-` to be recognised by the extension as a modal container.
+> A warning is emitted when a Div carries modal-specific attributes but its identifier is missing the prefix.
 
 ```{.markdown shortcodes=false}
 :::: {#modal-<id> description="<accessibility-description>" <options>}
@@ -87,6 +88,15 @@ Body content goes here.
 Footer content goes here.
 :::
 ```
+
+The `size` attribute accepts the Bootstrap tokens (`sm`, `lg`, `xl`) and friendly aliases (`small`, `medium`/`default`, `large`, `extra-large`/`xlarge`).
+Unknown values emit a warning and fall back to the default size.
+
+The `description` attribute sets `aria-describedby` and must reference an element present elsewhere in the document; otherwise a warning is emitted.
+
+Add `close-button="false"` to suppress the close button rendered in the modal header, or `close-button-label="..."` to override its `aria-label`.
+
+Nested modal containers are detected during rendering and trigger a warning: Bootstrap does not support modal nesting.
 
 ## Example
 

--- a/_extensions/modal/_extension.yml
+++ b/_extensions/modal/_extension.yml
@@ -1,6 +1,6 @@
 title: Modal
 author: Mickaël Canouil
-version: 1.5.0
+version: 1.4.2
 quarto-required: ">=1.7.32"
 contributes:
   filters:

--- a/_extensions/modal/_extension.yml
+++ b/_extensions/modal/_extension.yml
@@ -1,9 +1,9 @@
 title: Modal
 author: Mickaël Canouil
-version: 1.4.2
+version: 1.5.0
 quarto-required: ">=1.7.32"
 contributes:
   filters:
     - modal-filter.lua
-  shortcodes: 
+  shortcodes:
     - modal-shortcode.lua

--- a/_extensions/modal/_modules/content-extraction.lua
+++ b/_extensions/modal/_modules/content-extraction.lua
@@ -1,5 +1,5 @@
 --- MC Content Extraction - Content processing and extraction utilities for Quarto extensions
---- @module content_extraction
+--- @module "content_extraction"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/modal/_modules/html.lua
+++ b/_extensions/modal/_modules/html.lua
@@ -1,5 +1,5 @@
 --- MC HTML - HTML generation and dependency management for Quarto Lua filters and shortcodes
---- @module html
+--- @module "html"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/modal/_modules/logging.lua
+++ b/_extensions/modal/_modules/logging.lua
@@ -1,5 +1,5 @@
 --- MC Logging - Formatted log output for Quarto Lua filters and shortcodes
---- @module logging
+--- @module "logging"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/modal/_modules/metadata.lua
+++ b/_extensions/modal/_modules/metadata.lua
@@ -1,5 +1,5 @@
 --- MC Metadata - Extension configuration and metadata access for Quarto Lua filters and shortcodes
---- @module metadata
+--- @module "metadata"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/modal/_modules/pandoc-helpers.lua
+++ b/_extensions/modal/_modules/pandoc-helpers.lua
@@ -1,5 +1,5 @@
 --- MC Pandoc Helpers - Pandoc element construction and format detection for Quarto Lua filters and shortcodes
---- @module pandoc_helpers
+--- @module "pandoc_helpers"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/modal/_modules/string.lua
+++ b/_extensions/modal/_modules/string.lua
@@ -1,5 +1,5 @@
 --- MC String - String manipulation and escaping for Quarto Lua filters and shortcodes
---- @module string
+--- @module "string"
 --- @license MIT
 --- @copyright 2026 Mickaël Canouil
 --- @author Mickaël Canouil

--- a/_extensions/modal/_schema.yml
+++ b/_extensions/modal/_schema.yml
@@ -2,14 +2,14 @@
 # Provides configuration validation and IDE support for options,
 # shortcodes, and attributes.
 
-$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v2/extension-schema.json
 
 options:
   size:
     type: string
     default: ""
     enum: ["", sm, lg, xl, small, medium, default, large, extra-large, xlarge]
-    enum-case-insensitive: true
+    enumCaseInsensitive: true
     description: "Default modal dialog size. Friendly aliases small/medium/large/extra-large resolve to sm/(default)/lg/xl."
   backdrop-static:
     type: boolean
@@ -36,7 +36,7 @@ options:
     type: string
     default: "false"
     enum: ["false", "true", sm, md, lg, xl, xxl]
-    enum-case-insensitive: true
+    enumCaseInsensitive: true
     description: "Make the modal fullscreen. Set to a breakpoint (sm, md, lg, xl, xxl) for responsive fullscreen below that breakpoint."
 
 shortcodes:
@@ -68,7 +68,7 @@ attributes:
     size:
       type: string
       enum: ["", sm, lg, xl, small, medium, default, large, extra-large, xlarge]
-      enum-case-insensitive: true
+      enumCaseInsensitive: true
       description: "Modal dialog size override. Friendly aliases small/medium/large/extra-large resolve to sm/(default)/lg/xl."
     backdrop-static:
       type: boolean
@@ -89,7 +89,7 @@ attributes:
     fullscreen:
       type: string
       enum: ["false", "true", sm, md, lg, xl, xxl]
-      enum-case-insensitive: true
+      enumCaseInsensitive: true
       description: "Make this modal fullscreen or responsive fullscreen."
     description:
       type: string

--- a/_extensions/modal/_schema.yml
+++ b/_extensions/modal/_schema.yml
@@ -8,9 +8,9 @@ options:
   size:
     type: string
     default: ""
-    enum: ["", sm, lg, xl]
+    enum: ["", sm, lg, xl, small, medium, default, large, extra-large, xlarge]
     enum-case-insensitive: true
-    description: "Default modal dialog size."
+    description: "Default modal dialog size. Friendly aliases small/medium/large/extra-large resolve to sm/(default)/lg/xl."
   backdrop-static:
     type: boolean
     default: false
@@ -67,9 +67,9 @@ attributes:
   modal:
     size:
       type: string
-      enum: ["", sm, lg, xl]
+      enum: ["", sm, lg, xl, small, medium, default, large, extra-large, xlarge]
       enum-case-insensitive: true
-      description: "Modal dialog size override."
+      description: "Modal dialog size override. Friendly aliases small/medium/large/extra-large resolve to sm/(default)/lg/xl."
     backdrop-static:
       type: boolean
       description: "Use a static backdrop for this modal."
@@ -93,7 +93,15 @@ attributes:
       description: "Make this modal fullscreen or responsive fullscreen."
     description:
       type: string
-      description: "Accessible description for the modal (aria-describedby)."
+      description: "Accessible description for the modal (aria-describedby). Must reference the identifier of an element present elsewhere in the document; a warning is emitted otherwise."
+    close-button:
+      type: boolean
+      default: true
+      description: "Whether to render the Bootstrap close button in the modal header."
+    close-button-label:
+      type: string
+      default: "Close"
+      description: "Accessible label (aria-label) for the close button in the modal header."
 
 classes:
   modal:

--- a/_extensions/modal/modal-filter.lua
+++ b/_extensions/modal/modal-filter.lua
@@ -35,6 +35,59 @@ local modal_settings_meta = {
   ["fullscreen"] = "false"
 }
 
+--- Friendly size presets that map to Bootstrap sizes.
+--- Empty string keeps Bootstrap's default 500px width.
+--- @type table<string, string>
+local SIZE_PRESETS = {
+  ["small"] = "sm",
+  ["sm"] = "sm",
+  ["medium"] = "",
+  ["default"] = "",
+  [""] = "",
+  ["large"] = "lg",
+  ["lg"] = "lg",
+  ["extra-large"] = "xl",
+  ["xlarge"] = "xl",
+  ["xl"] = "xl"
+}
+
+--- Valid fullscreen breakpoint values, excluding boolean strings.
+--- @type table<string, boolean>
+local FULLSCREEN_BREAKPOINTS = {
+  ["sm"] = true,
+  ["md"] = true,
+  ["lg"] = true,
+  ["xl"] = true,
+  ["xxl"] = true
+}
+
+--- Attribute names that mark a Div as intended to be a modal.
+--- Used to detect Divs with modal-specific configuration but an
+--- identifier missing the required ``modal-`` prefix.
+--- @type table<integer, string>
+local MODAL_ATTRIBUTE_HINTS = {
+  "size",
+  "backdrop-static",
+  "scrollable",
+  "keyboard",
+  "centred",
+  "centered",
+  "fade",
+  "fullscreen",
+  "description",
+  "close-button",
+  "close-button-label"
+}
+
+--- Set of identifiers present anywhere in the document.
+--- Populated during the Meta pass before Div processing.
+--- @type table<string, boolean>
+local document_ids = {}
+
+--- Set of modal identifiers (after Div processing) used by Link expansion.
+--- @type table<string, boolean>
+local modal_ids = {}
+
 --- Get modal option from metadata.
 --- @param key string The option name to retrieve.
 --- @param meta table<string, any> Document metadata table.
@@ -48,12 +101,83 @@ local function get_modal_option(key, meta)
   return modal_settings_meta[key] or ''
 end
 
+--- Resolve a user-supplied size value to a Bootstrap size token.
+--- Accepts both raw Bootstrap tokens (``sm``/``lg``/``xl``) and friendly
+--- aliases (``small``/``large``/``extra-large``).
+--- Emits a warning and returns the empty default when the value is unknown.
+--- @param value string|nil User-supplied size value.
+--- @return string Resolved Bootstrap size token (one of "", "sm", "lg", "xl").
+local function resolve_size(value)
+  if value == nil or value == '' then
+    return ''
+  end
+  local normalised = value:lower()
+  local resolved = SIZE_PRESETS[normalised]
+  if resolved == nil then
+    log.log_warning(
+      EXTENSION_NAME,
+      "Unknown 'size' value '" .. value .. "'. " ..
+      "Expected one of: small/sm, medium/default, large/lg, extra-large/xlarge/xl. " ..
+      "Falling back to the default size."
+    )
+    return ''
+  end
+  return resolved
+end
+
+--- Collect every identifier appearing anywhere in the document.
+--- Walks Pandoc blocks and inlines exactly once so later validations
+--- (e.g. ``description`` references) can resolve targets cheaply.
+--- @param doc table Pandoc Pandoc element.
+local function collect_document_ids(doc)
+  document_ids = {}
+  pandoc.walk_block(pandoc.Div(doc.blocks), {
+    Div = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end,
+    Header = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end,
+    Span = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end,
+    Link = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end,
+    Image = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end,
+    CodeBlock = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end,
+    Table = function(el)
+      if el.identifier and el.identifier ~= '' then
+        document_ids[el.identifier] = true
+      end
+    end
+  })
+end
+
 
 --- Extract and configure modal settings from document metadata.
 ---
---- @param meta table<string, any> Document metadata table.
---- @return table<string, any> Updated metadata table with modal configuration.
-local function get_modal_meta(meta)
+--- @param doc table Pandoc Pandoc element.
+--- @return table Updated Pandoc Pandoc element.
+local function get_modal_meta(doc)
+  modal_ids = {}
+  local meta = doc.meta
   local modal_options = {}
   for key, _ in pairs(modal_settings_meta) do
     modal_options[key] = get_modal_option(key, meta)
@@ -66,15 +190,68 @@ local function get_modal_meta(meta)
     end
   end
   modal_settings_meta = meta['extensions']['modal']
-  return meta
+  doc.meta = meta
+  collect_document_ids(doc)
+  return doc
 end
 
---- Filter for Divs with id starting with 'modal-'.
+--- Check whether a Div carries any attribute that suggests it was meant
+--- to be a modal but is missing the ``modal-`` identifier prefix.
+--- @param el table Pandoc Div element.
+--- @return boolean True if any modal-specific attribute is set.
+local function has_modal_attributes(el)
+  if not el.attributes then return false end
+  for _, attr_name in ipairs(MODAL_ATTRIBUTE_HINTS) do
+    local value = el.attributes[attr_name]
+    if value ~= nil and value ~= '' then
+      return true
+    end
+  end
+  return false
+end
+
+--- Detect modal Divs nested inside the supplied blocks and warn.
+--- HTML and Bootstrap do not support nesting modals; nested modals are
+--- almost always a markup mistake and lead to focus and backdrop issues.
+--- @param blocks table<integer, table> Blocks to scan.
+--- @param parent_id string Identifier of the enclosing modal.
+local function warn_on_nested_modals(blocks, parent_id)
+  if blocks == nil then return end
+  pandoc.walk_block(pandoc.Div(blocks), {
+    Div = function(child)
+      if child.identifier and child.identifier:match('^modal%-') then
+        log.log_warning(
+          EXTENSION_NAME,
+          "Modal '" .. parent_id .. "' contains nested modal '" .. child.identifier .. "'. " ..
+          "Bootstrap does not support modal nesting; please move the nested modal out of its parent."
+        )
+      end
+    end
+  })
+end
+
+--- Process Divs whose identifier starts with ``modal-``.
+--- Invoked by Pandoc on every Div; returns ``nil`` (leaving the Div
+--- untouched) when the Div is not a modal container or when the active
+--- format does not support Bootstrap modals.
 ---
 --- @param el table Pandoc Div element.
---- @return table|nil Pandoc Div structure for modal, or nil if not applicable.
+--- @return table|nil Pandoc Div structure for a modal, or nil if not applicable.
 local function modal(el)
-  if not quarto.doc.is_format("html:js") or not quarto.doc.has_bootstrap() or not (el.identifier:match("^modal%-")) then
+  if not quarto.doc.is_format("html:js") or not quarto.doc.has_bootstrap() then
+    return nil
+  end
+
+  local has_modal_prefix = el.identifier:match("^modal%-") ~= nil
+  if not has_modal_prefix then
+    if has_modal_attributes(el) then
+      log.log_warning(
+        EXTENSION_NAME,
+        "Div '" .. (el.identifier ~= '' and el.identifier or '(no id)') ..
+        "' carries modal-specific attributes but its identifier does not start with 'modal-'. " ..
+        "Modal Divs must use an identifier like '#modal-my-id'."
+      )
+    end
     return nil
   end
 
@@ -87,7 +264,10 @@ local function modal(el)
   })
 
   local modal_id = el.identifier ~= '' and el.identifier or unique_modal_id()
-  local modal_size = el.attributes.size or modal_settings_meta["size"]
+  modal_ids[modal_id] = true
+
+  local raw_size = el.attributes.size or modal_settings_meta["size"]
+  local modal_size = resolve_size(raw_size)
   local modal_backdrop_static = el.attributes["backdrop-static"] or modal_settings_meta["backdrop-static"]
   local modal_scrollable = el.attributes.scrollable or modal_settings_meta["scrollable"]
   local modal_keyboard = el.attributes.keyboard or modal_settings_meta["keyboard"]
@@ -116,8 +296,14 @@ local function modal(el)
   if modal_centred == 'true' then table.insert(dialog_classes, 'modal-dialog-centered') end
   if modal_fullscreen == 'true' then
     table.insert(dialog_classes, 'modal-fullscreen')
-  elseif modal_fullscreen and modal_fullscreen:match('^(sm|md|lg|xl|xxl)$') then
+  elseif modal_fullscreen and FULLSCREEN_BREAKPOINTS[modal_fullscreen] then
     table.insert(dialog_classes, 'modal-fullscreen-' .. modal_fullscreen .. '-down')
+  elseif modal_fullscreen and modal_fullscreen ~= 'false' and modal_fullscreen ~= '' then
+    log.log_warning(
+      EXTENSION_NAME,
+      "Unknown 'fullscreen' value '" .. modal_fullscreen .. "' on modal '" .. modal_id .. "'. " ..
+      "Expected one of: false, true, sm, md, lg, xl, xxl. Falling back to no fullscreen."
+    )
   end
 
   --- Parse modal sections
@@ -127,14 +313,32 @@ local function modal(el)
   local body_blocks = parsed.body_blocks
   local footer_blocks = parsed.footer_blocks
 
+  warn_on_nested_modals(body_blocks, modal_id)
+  warn_on_nested_modals(footer_blocks, modal_id)
+
   local modal_header_id = header_text and str.ascii_id(header_text) or "modal-title"
 
-  local modal_header_html = pandoc.RawBlock('html',
-    html_mod.raw_header(header_level, header_text, modal_header_id, { 'modal-title' }, nil) ..
-    '\n' ..
-    '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>'
+  --- Optional close button in the header (Bootstrap-rendered "x").
+  --- ``close-button=false`` suppresses it; ``close-button-label`` overrides
+  --- the default aria-label (useful for localisation).
+  local close_button_attr = el.attributes['close-button']
+  local include_close_button = close_button_attr == nil or close_button_attr ~= 'false'
+  local close_button_label = el.attributes['close-button-label'] or 'Close'
+
+  local header_html = html_mod.raw_header(
+    header_level,
+    header_text,
+    modal_header_id,
+    { 'modal-title' },
+    nil
   )
-  local modal_header = pandoc.Div({ modal_header_html }, pdoc.attr('', { 'modal-header' }))
+  if include_close_button then
+    header_html = header_html ..
+        '\n' ..
+        '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="' ..
+        str.escape_attribute(close_button_label) .. '"></button>'
+  end
+  local modal_header = pandoc.Div({ pandoc.RawBlock('html', header_html) }, pdoc.attr('', { 'modal-header' }))
 
   local modal_content = { modal_header }
   if #body_blocks > 0 then
@@ -152,6 +356,13 @@ local function modal(el)
     ['aria-labelledby'] = modal_header_id
   }
   if modal_description then
+    if not document_ids[modal_description] then
+      log.log_warning(
+        EXTENSION_NAME,
+        "Modal '" .. modal_id .. "' has description='" .. modal_description ..
+        "' but no element with that identifier exists in the document."
+      )
+    end
     modal_attrs['aria-describedby'] = modal_description
   end
   if modal_backdrop_static == 'true' then
@@ -173,20 +384,33 @@ local function modal(el)
   return modal_structure
 end
 
+--- Expand bare Markdown links to a ``#modal-*`` anchor into Bootstrap
+--- modal triggers.
+---
+--- Runs at the ``pre-quarto`` filter stage, where Pandoc-style attribute
+--- names (``bs-target``, ``bs-toggle``) have not yet been prefixed with
+--- ``data-`` by Quarto. The filter checks (and writes) the unprefixed
+--- names so that author intent is preserved: if the link already declares
+--- a Bootstrap toggle or target, the filter leaves it alone.
+--- @param el table Pandoc Link element.
+--- @return table Possibly-modified Link element.
+local function expand_modal_link(el)
+  if not el.target or not el.target:match('^#modal%-') then
+    return el
+  end
+  if el.attributes['bs-toggle'] ~= nil and el.attributes['bs-toggle'] ~= '' then
+    return el
+  end
+  if el.attributes['bs-target'] ~= nil and el.attributes['bs-target'] ~= '' then
+    return el
+  end
+  el.attributes['bs-target'] = el.target
+  el.attributes['bs-toggle'] = 'modal'
+  return el
+end
+
 return {
-  { Meta = get_modal_meta },
+  { Pandoc = get_modal_meta },
   { Div = modal },
-  {
-    Link = function(el)
-      if el.target and not el.target:match('^#modal%-') then
-        return el
-      end
-      if el.attributes['data-bs-toggle'] == 'modal' then
-        return el
-      end
-      el.attributes['data-bs-target'] = el.target
-      el.attributes['data-bs-toggle'] = 'modal'
-      return el
-    end
-  }
+  { Link = expand_modal_link }
 }

--- a/_extensions/modal/modal-filter.lua
+++ b/_extensions/modal/modal-filter.lua
@@ -80,13 +80,9 @@ local MODAL_ATTRIBUTE_HINTS = {
 }
 
 --- Set of identifiers present anywhere in the document.
---- Populated during the Meta pass before Div processing.
+--- Populated during the Pandoc pass before Div processing.
 --- @type table<string, boolean>
 local document_ids = {}
-
---- Set of modal identifiers (after Div processing) used by Link expansion.
---- @type table<string, boolean>
-local modal_ids = {}
 
 --- Get modal option from metadata.
 --- @param key string The option name to retrieve.
@@ -131,52 +127,27 @@ end
 --- @param doc table Pandoc Pandoc element.
 local function collect_document_ids(doc)
   document_ids = {}
-  pandoc.walk_block(pandoc.Div(doc.blocks), {
-    Div = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
-    end,
-    Header = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
-    end,
-    Span = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
-    end,
-    Link = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
-    end,
-    Image = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
-    end,
-    CodeBlock = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
-    end,
-    Table = function(el)
-      if el.identifier and el.identifier ~= '' then
-        document_ids[el.identifier] = true
-      end
+  local function record(el)
+    if el.identifier and el.identifier ~= '' then
+      document_ids[el.identifier] = true
     end
+  end
+  pandoc.walk_block(pandoc.Div(doc.blocks), {
+    Div = record,
+    Header = record,
+    Span = record,
+    Link = record,
+    Image = record,
+    CodeBlock = record,
+    Table = record
   })
 end
-
 
 --- Extract and configure modal settings from document metadata.
 ---
 --- @param doc table Pandoc Pandoc element.
 --- @return table Updated Pandoc Pandoc element.
 local function get_modal_meta(doc)
-  modal_ids = {}
   local meta = doc.meta
   local modal_options = {}
   for key, _ in pairs(modal_settings_meta) do
@@ -264,7 +235,6 @@ local function modal(el)
   })
 
   local modal_id = el.identifier ~= '' and el.identifier or unique_modal_id()
-  modal_ids[modal_id] = true
 
   local raw_size = el.attributes.size or modal_settings_meta["size"]
   local modal_size = resolve_size(raw_size)
@@ -282,16 +252,8 @@ local function modal(el)
   local modal_fade = el.attributes.fade or modal_settings_meta["fade"]
   local modal_fullscreen = el.attributes.fullscreen or modal_settings_meta["fullscreen"]
 
-  local size_class = ''
-  if modal_size == 'lg' then
-    size_class = 'modal-lg'
-  elseif modal_size == 'sm' then
-    size_class = 'modal-sm'
-  elseif modal_size == 'xl' then
-    size_class = 'modal-xl'
-  end
   local dialog_classes = { 'modal-dialog' }
-  if size_class ~= '' then table.insert(dialog_classes, size_class) end
+  if modal_size ~= '' then table.insert(dialog_classes, 'modal-' .. modal_size) end
   if modal_scrollable == 'true' then table.insert(dialog_classes, 'modal-dialog-scrollable') end
   if modal_centred == 'true' then table.insert(dialog_classes, 'modal-dialog-centered') end
   if modal_fullscreen == 'true' then
@@ -347,7 +309,6 @@ local function modal(el)
   if #footer_blocks > 0 then
     table.insert(modal_content, pandoc.Div(content.protect_headers(footer_blocks, '', 'html'), pdoc.attr('', { 'modal-footer' })))
   end
-
 
   local modal_description = el.attributes.description
   local modal_attrs = {

--- a/example.qmd
+++ b/example.qmd
@@ -30,7 +30,7 @@ It allows you to define modal buttons and containers using shortcodes, making it
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-modal@1.5.0
+quarto add mcanouil/quarto-modal@1.4.2
 ```
 
 This will install the extension under the `_extensions` subdirectory.

--- a/example.qmd
+++ b/example.qmd
@@ -30,7 +30,7 @@ It allows you to define modal buttons and containers using shortcodes, making it
 ## Installation
 
 ```bash
-quarto add mcanouil/quarto-modal@1.4.2
+quarto add mcanouil/quarto-modal@1.5.0
 ```
 
 This will install the extension under the `_extensions` subdirectory.
@@ -519,6 +519,153 @@ This modal has a custom footer.
 {{< modal dismiss target="modal-footer" label="Cancel" >}}
 {{< modal dismiss target="modal-footer" label="OK" >}}
 :::
+
+:::
+```
+
+## Friendly Size Aliases
+
+The `size` attribute accepts both Bootstrap tokens (`sm`, `lg`, `xl`) and friendly aliases (`small`, `medium`, `large`, `extra-large`/`xlarge`).
+Unknown values trigger a warning during rendering and fall back to the default size.
+
+{{< modal toggle target="modal-friendly-size" label="Open Friendly Size Modal" >}}
+
+:::: {#modal-friendly-size size="large"}
+
+## Friendly Size Modal
+
+This modal uses the `large` alias, which resolves to `modal-lg`.
+
+---
+
+{{< modal dismiss target="modal-friendly-size" label="Close" >}}
+
+:::
+
+```{.markdown shortcodes=false}
+{{< modal toggle target="modal-friendly-size" label="Open Friendly Size Modal" >}}
+
+:::: {#modal-friendly-size size="large"}
+
+## Friendly Size Modal
+
+This modal uses the `large` alias, which resolves to `modal-lg`.
+
+---
+
+{{< modal dismiss target="modal-friendly-size" label="Close" >}}
+
+:::
+```
+
+## Customising the Close Button
+
+Set `close-button="false"` to hide the default close button in the modal header.
+Use `close-button-label="..."` to override the `aria-label` text, which is useful for localisation.
+
+{{< modal toggle target="modal-close-custom" label="Open Modal With Custom Close" >}}
+
+:::: {#modal-close-custom close-button-label="Fermer"}
+
+## Custom Close Label
+
+The close button in the header uses a translated `aria-label`.
+
+---
+
+{{< modal dismiss target="modal-close-custom" label="Fermer" >}}
+
+:::
+
+```{.markdown shortcodes=false}
+{{< modal toggle target="modal-close-custom" label="Open Modal With Custom Close" >}}
+
+:::: {#modal-close-custom close-button-label="Fermer"}
+
+## Custom Close Label
+
+The close button in the header uses a translated `aria-label`.
+
+---
+
+{{< modal dismiss target="modal-close-custom" label="Fermer" >}}
+
+:::
+```
+
+{{< modal toggle target="modal-no-close" label="Open Modal Without Header Close" >}}
+
+:::: {#modal-no-close close-button="false"}
+
+## No Header Close
+
+The header close button is suppressed; users dismiss the modal via the footer.
+
+---
+
+{{< modal dismiss target="modal-no-close" label="Close" >}}
+
+:::
+
+```{.markdown shortcodes=false}
+{{< modal toggle target="modal-no-close" label="Open Modal Without Header Close" >}}
+
+:::: {#modal-no-close close-button="false"}
+
+## No Header Close
+
+The header close button is suppressed; users dismiss the modal via the footer.
+
+---
+
+{{< modal dismiss target="modal-no-close" label="Close" >}}
+
+:::
+```
+
+## Accessible Description
+
+The `description` attribute sets `aria-describedby` on the modal and must reference the identifier of an element present elsewhere in the document.
+A warning is emitted when the referenced identifier cannot be resolved.
+
+::: {#described-modal-note}
+
+The modal below references this paragraph for its accessible description.
+
+:::
+
+{{< modal toggle target="modal-described" label="Open Described Modal" >}}
+
+:::: {#modal-described description="described-modal-note"}
+
+## Described Modal
+
+This modal exposes an extended description via `aria-describedby`.
+
+---
+
+{{< modal dismiss target="modal-described" label="Close" >}}
+
+:::
+
+```{.markdown shortcodes=false}
+::: {#described-modal-note}
+
+The modal below references this paragraph for its accessible description.
+
+:::
+
+{{< modal toggle target="modal-described" label="Open Described Modal" >}}
+
+:::: {#modal-described description="described-modal-note"}
+
+## Described Modal
+
+This modal exposes an extended description via `aria-describedby`.
+
+---
+
+{{< modal dismiss target="modal-described" label="Close" >}}
 
 :::
 ```


### PR DESCRIPTION
Action the review findings recorded under `quarto-modal (v1.4.2)`.
Fix the long-standing link-expansion bug (the filter wrote `bs-*` attributes during the `pre-quarto` stage where Pandoc still exposes the unprefixed names, so author-supplied `bs-toggle="collapse"` was silently overwritten by Quarto's later normalisation), clarify a misleading comment, and add the agreed warnings and customisation knobs.

- fix(filter): Preserve pre-existing `bs-toggle`/`bs-target` on link expansion by checking and writing the unprefixed attribute names that exist at the `pre-quarto` stage.
- feat(filter): Warn when a Div carries modal-specific attributes (`size`, `centred`, `description`, ...) but its identifier does not start with `modal-`.
- feat(filter): Validate `description` references against the set of identifiers collected from the document and warn when the target is missing.
- feat(filter): Detect nested modal containers (forbidden by Bootstrap) and warn with both parent and child identifiers.
- feat(filter): Add friendly `size` aliases (`small`, `medium`/`default`, `large`, `extra-large`/`xlarge`) and warn on unknown size values; warn on unknown `fullscreen` values instead of silently omitting the class.
- feat(filter): Add `close-button` (suppress the header close button) and `close-button-label` (override the `aria-label`) attributes.
- refactor(filter): Replace the per-document `Meta` filter with `Pandoc` so identifier collection and metadata defaults run in a single pass; reset cross-document state on entry.
- refactor(comment): Clarify that the Div callback is invoked on every Div and processes only those whose identifier starts with `modal-`.
- chore(modules): Synchronise shared modules (`content-extraction.lua`, `html.lua`, `logging.lua`, `metadata.lua`, `pandoc-helpers.lua`, `string.lua`) with the canonical version.
- docs(schema): Extend `_schema.yml` enum for `size` with the friendly aliases and document the new `close-button`/`close-button-label` attributes.
- docs(readme, example): Document and demonstrate the friendly aliases, close-button customisation, `description` validation, and nested-modal warning.
- docs(changelog): Add entries under `## Unreleased`; the release workflow handles the version bump and dated heading.
