### PR TITLE
fix: declare the filter entry point in the extension manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: Register the filter at `pre-quarto` in the extension manifest, so listing `modal` under `filters` is enough and the entry point no longer has to be named in project or document YAML.
+- fix: Raise `quarto-required` to `>=1.9.38`, the first version whose `_extension.yml` schema accepts a filter entry point.
+
 ## 1.5.1 (2026-08-01)
 
 ### Bug Fixes

--- a/_extensions/modal/_extension.yml
+++ b/_extensions/modal/_extension.yml
@@ -1,9 +1,10 @@
 title: Modal
 author: Mickaël Canouil
 version: 1.5.1
-quarto-required: ">=1.7.32"
+quarto-required: ">=1.9.38"
 contributes:
   filters:
-    - modal-filter.lua
+    - path: modal-filter.lua
+      at: pre-quarto
   shortcodes:
     - modal-shortcode.lua

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -40,8 +40,7 @@ Enable the filter:
 
 ```yaml
 filters:
-  - path: modal
-    at: pre-quarto
+  - modal
 ```
 
 Then write the container and a button that opens it:

--- a/docs/reference.qmd
+++ b/docs/reference.qmd
@@ -8,8 +8,7 @@ description: "The complete modal configuration: the container div, the toggle an
 
 ```yaml
 filters:
-  - path: modal
-    at: pre-quarto
+  - modal
 ```
 
 ## The container

--- a/example.qmd
+++ b/example.qmd
@@ -9,8 +9,7 @@ format:
   html:
     toc: true
 filters:
-  - path: modal
-    at: pre-quarto
+  - modal
 extensions:
   modal:
     fade: true


### PR DESCRIPTION
The extension manifest now registers the filter at `pre-quarto`, so listing `modal` under `filters` is enough and the entry point no longer has to be repeated in project or document YAML. The documentation and `example.qmd` use the short form throughout.

`quarto-required` moves to >=1.9.38, the first version whose `_extension.yml` schema accepts a filter entry point. Below it the render fails validation.