### PR TITLE
fix: default the modal button type when no argument is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- fix: The `modal` shortcode no longer stops the render when it is called with no button type. It applies the documented `toggle` default. (#41)
+
 ## 1.6.0 (2026-09-07)
 
 ### New Features

--- a/_extensions/modal/modal-shortcode.lua
+++ b/_extensions/modal/modal-shortcode.lua
@@ -40,7 +40,7 @@ local function modal(args, kwargs, _meta, _raw_args, _context)
     return pandoc.Null()
   end
 
-  local button_type = str.stringify(args[1]) or 'toggle'
+  local button_type = #args > 0 and str.stringify(args[1]) or 'toggle'
   local target = str.stringify(kwargs.target)
   local label = str.stringify(kwargs.label)
   local classes = str.stringify(kwargs.classes)


### PR DESCRIPTION
Calling the shortcode with no positional argument stopped the whole render with `Cannot get Attr from TypeNil`, because the `or 'toggle'` fallback was unreachable. The documented `toggle` default now applies.